### PR TITLE
Made git-merge-cleanup MacOS compatible

### DIFF
--- a/git-merged-cleanup
+++ b/git-merged-cleanup
@@ -21,10 +21,10 @@ if ! git log -1 &>/dev/null; then
 fi
 
 grep_changeid() {
-    sed -nr 's/ *Change-Id: ([A-Za-z0-9])/\1/p'
+    sed -nE 's/ *Change-Id: ([A-Za-z0-9])/\1/p'
 }
 strip_brmark() {
-    sed -r 's/[* ] //'
+    sed -E 's/[* ] //'
 }
 contains() {
     local e


### PR DESCRIPTION
sed -r does not exist on BSD but -E is standard.

Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>